### PR TITLE
Fix crashes on first execution

### DIFF
--- a/src/utils/brew/manager.go
+++ b/src/utils/brew/manager.go
@@ -29,7 +29,10 @@ func (b BrewManager) GetCurrentUpgradablePackages() []string {
 func refreshUpdatableListManager(b BrewManager, updatableListManager *UpdatableListManager) {
 	b.UpdateInfo()
 	updatableListManager.Packages = b.GetCurrentUpgradablePackages()
-	updatableListManager.Save()
+
+	if err := updatableListManager.Save(); err != nil {
+		panic(err)
+	}
 }
 
 func (b BrewManager) GetUpgradablePackages() []string {

--- a/src/utils/brew/updatable_list_manager.go
+++ b/src/utils/brew/updatable_list_manager.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
+	"strings"
 	"sync"
 	"time"
 )
@@ -38,6 +39,14 @@ func (manager *UpdatableListManager) Save() error {
 		return err
 	}
 
+	splitted_path := strings.Split(manager.FILE_PATH, "/")
+	splitted_path = splitted_path[:len(splitted_path)-1]
+	directory_path := strings.Join(splitted_path, "/")
+
+	err = os.MkdirAll(directory_path, 0700)
+	if err != nil {
+		return err
+	}
 	err = ioutil.WriteFile(manager.FILE_PATH, jsonString, 0644)
 	if err != nil {
 		return err


### PR DESCRIPTION
The caching directory(`~/.local/share/brew_updates/updatable_packages_log.json`) is not available on first execution.
By using `os.MkdirAll()`, resolve this issue.